### PR TITLE
update apt and auto-installer, change pip mirror

### DIFF
--- a/kmucs.sh
+++ b/kmucs.sh
@@ -40,29 +40,30 @@ sudo apt -y install mysql-server
 sudo apt -y install mysql-workbench
 
 # Install MySQL JDBC
-sudo apt -y install libmysql-java 
+sudo apt -y install libmysql-java
 # Install django
 sudo apt -y install python3-pip
 sudo pip3 install --upgrade pip
-sudo pip3 install django
+sudo pip3 install django -i http://ftp.daumkakao.com/pypi/simple --trusted-host ftp.daumkakao.com
+
 
 # Install numpy
-sudo pip3 install numpy
+sudo pip3 install numpy -i http://ftp.daumkakao.com/pypi/simple --trusted-host ftp.daumkakao.com
 
 # Install scipy
-sudo pip3 install scipy
+sudo pip3 install scipy -i http://ftp.daumkakao.com/pypi/simple --trusted-host ftp.daumkakao.com
 
 # Install matplotlib
-sudo pip3 install matplotlib
+sudo pip3 install matplotlib -i http://ftp.daumkakao.com/pypi/simple --trusted-host ftp.daumkakao.com
 
 # Install pyyaml
-sudo pip3 install pyyaml
+sudo pip3 install pyyaml -i http://ftp.daumkakao.com/pypi/simple --trusted-host ftp.daumkakao.com
 
 # Install nltk
-sudo pip3 install nltk
+sudo pip3 install nltk -i http://ftp.daumkakao.com/pypi/simple --trusted-host ftp.daumkakao.com
 
 # Install scikit-learn
-sudo pip3 install scikit-learn
+sudo pip3 install scikit-learn -i http://ftp.daumkakao.com/pypi/simple --trusted-host ftp.daumkakao.com
 
 # Install hadoop
 sudo wget http://apache.mirror.cdnetworks.com/hadoop/common/hadoop-2.8.1/hadoop-2.8.1.tar.gz

--- a/kmucs.sh
+++ b/kmucs.sh
@@ -3,45 +3,45 @@
 # Change apt repository
 sudo sed -i 's/kr.archive.ubuntu.com/ftp.daumkakao.com/g' /etc/apt/sources.list
 
-sudo apt-get -y update
-sudo apt-get -y upgrade
+# update/upgrade system
+sudo apt -y update && sudo apt -y upgrade
 
 # Install VIM
-sudo apt-get -y install vim
+sudo apt -y install vim
 
 # Install gcc
-sudo apt-get -y install build-essential
+sudo apt -y install build-essential
 
 # Install Java oracle-8
 sudo add-apt-repository -y ppa:webupd8team/java
-sudo apt-get -y update
+sudo apt -y update
 sudo debconf-set-selections <<< 'oracle-java8-installer shared/accepted-oracle-licnese-v1-1 select true'
-sudo apt-get -y install oracle-java8-installer
+sudo apt -y install oracle-java8-installer
 
 # Install Eclipse
-sudo apt-get -y install eclipse
+sudo apt -y install eclipse
 
 # Install R
-sudo apt-get -y install r-base
+sudo apt -y install r-base
 
 # Install Git
-sudo apt-get -y install git
+sudo apt -y install git
 
 # Install RBTools
-sudo apt-get -y install python-rbtools
+sudo apt -y install python-rbtools
 
 # Install MySQL
 sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password kmucs'
 sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password passwordi_again kmucs'
-sudo apt-get -y install mysql-server
+sudo apt -y install mysql-server
 
 # Install MySQL Workbench
-sudo apt-get -y install mysql-workbench
+sudo apt -y install mysql-workbench
 
 # Install MySQL JDBC
-sudo apt-get -y install libmysql-java 
+sudo apt -y install libmysql-java 
 # Install django
-sudo apt-get -y install python3-pip
+sudo apt -y install python3-pip
 sudo pip3 install --upgrade pip
 sudo pip3 install django
 
@@ -79,10 +79,10 @@ sudo rm spark-2.2.0-bin-hadoop2.7.tgz
 sudo ln -s /usr/local/spark-2.2.0-bin-hadoop2.7 /usr/local/spark
 
 # Enable apt over https
-sudo apt-get -y install apt-transport-https
+sudo apt -y install apt-transport-https
 
 # Install sbt
 echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-sudo apt-get update
-sudo apt-get -y install sbt
+sudo apt update
+sudo apt -y install sbt

--- a/kmucs.sh
+++ b/kmucs.sh
@@ -15,7 +15,8 @@ sudo apt -y install build-essential
 # Install Java oracle-8
 sudo add-apt-repository -y ppa:webupd8team/java
 sudo apt -y update
-sudo debconf-set-selections <<< 'oracle-java8-installer shared/accepted-oracle-licnese-v1-1 select true'
+sudo apt-get install -y software-properties-common debconf-utils
+sudo echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
 sudo apt -y install oracle-java8-installer
 
 # Install Eclipse
@@ -32,7 +33,7 @@ sudo apt -y install python-rbtools
 
 # Install MySQL
 sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password kmucs'
-sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password passwordi_again kmucs'
+sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password kmucs'
 sudo apt -y install mysql-server
 
 # Install MySQL Workbench


### PR DESCRIPTION
설치 진행도가 나타나게 apt-get을 apt로 바꾸고, 자바와 mysql의 자동 세팅의 오류를 수정했습니다.
그리고 느린 pip install도 다음 카카오 서버로 변경했습니다 (50.8MB/s 까지 측정).

직접 테스트해본 후 PR 작성했습니다.